### PR TITLE
Function print_current_track_info requires a SoCo instance.

### DIFF
--- a/socos.py
+++ b/socos.py
@@ -56,7 +56,7 @@ def get_volume_adjustment_factor(operator):
     return factor
 
 
-def print_current_track_info():
+def print_current_track_info(sonos):
     track = sonos.get_current_track_info()
     print(
         "Current track: %s - %s. From album %s. This is track number"
@@ -139,7 +139,7 @@ def main():
         elif (cmd == 'previous'):
             print(sonos.previous())
         elif (cmd == 'current'):
-            print_current_track_info()
+            print_current_track_info(sonos)
         elif (cmd == 'queue'):
             print_queue()
         elif (cmd == 'volume'):


### PR DESCRIPTION
This patch fixes missing 'sonos' in print_current_track_info()
