### PR TITLE
Updated get_queue code to work with data structure changes in upstream

### DIFF
--- a/socos.py
+++ b/socos.py
@@ -229,9 +229,9 @@ def get_queue(sonos):
             "%s%s: %s - %s. From album %s." % (
                 color,
                 idx,
-                track['artist'],
-                track['title'],
-                track['album'],
+                track.creator,
+                track.title,
+                track.album,
             )
         )
 


### PR DESCRIPTION
This simple change changes the get_queue method so that it works with the (data structure changes in upstream soco)[https://github.com/SoCo/SoCo/pull/93]. In upstream get_queue now returns a list of QueueItem as supposed to earlier where it was a list of dicts. In these QueueItems the title, album and creator info is now available as named attributes.
