### PR TITLE
Play index exception

### DIFF
--- a/socos/core.py
+++ b/socos/core.py
@@ -258,7 +258,7 @@ def play_index(sonos, index):
     index = int(index) - 1
     if index >= 0 and index < queue_length:
         current = int(sonos.get_current_track_info()['playlist_position']) - 1
-        if (index != current):
+        if index != current:
             return sonos.play_from_queue(index)
     else:
         raise ValueError("Index has to be a integer within \


### PR DESCRIPTION
I found redundant '()' which caused the original exception in 'play_index' to not be caught, but then I realized it could be changed a bit more, seems to work better now, to test it simply run play 11 on a queue with 10 tracks.
