### PR TITLE
Adds remove 'index' command.

### DIFF
--- a/socos/core.py
+++ b/socos/core.py
@@ -277,9 +277,7 @@ def play_index(sonos, index):
         if index != current:
             return sonos.play_from_queue(index)
     else:
-        error = "Index %d is not within range 1 - %d" % (
-                index,
-                queue_length)
+        error = "Index %d is not within range 1 - %d" % (index, queue_length)
         raise ValueError(error)
 
 


### PR DESCRIPTION
adds

```
remove 10
```

returns the updated queue.

This however causes a exception when index is outside of the actual queue, the reason I'm not fixing this yet is because I prefer to fix that in one way under #14 and then 'reproduce' whatever solution we end up with there for similar usecases like this one.
