### PR TITLE
Music library support

### DIFF
--- a/socos.py
+++ b/socos.py
@@ -278,6 +278,10 @@ class MusicLibrary(object):
                 # Perform the search in Sqlite3
                 query = 'SELECT * FROM {} WHERE {} LIKE ?'.format(data_type,
                                                                   field)
+                try:
+                    search = search.decode('utf-8')
+                except AttributeError:
+                    pass
                 self.cursor.execute(query, [search])
                 results = self.cursor.fetchall()
                 # Add results to the cache and reduce cache length if necesary
@@ -704,6 +708,7 @@ def get_help(command=None):
 # If requires_ip is False, function must be a callable.
 COMMANDS = OrderedDict((
     #  cmd         req IP  func
+    # pylint: disable=bad-whitespace
     ('list',         (False, list_ips)),
     ('partymode',    (True, 'partymode')),
     ('info',         (True, speaker_info)),


### PR DESCRIPTION
This branch implements music library support in socos. It depends on data structures currently only in SoCo master, so it should not be merged before SoCo has seen a new commit.

Following some comments about in the long run refactoring socos into several classes, where each class would cover some set of functionality, I have implemented all the functionality for music library support in a class of its own.

The implementation is made by forming a local (Sqlite3) database of all tracks, albums, artists and imported playlists in the music library. This database is saved in a file, so it will lasts between socos executions. After indexing it is then possibly to search and play (add to/replace queue). The indexing is done with the `ml_index` command. After indexing, the searches are done with the four commands `ml_tracks`, `ml_albums`, `ml_artists` and `ml_playlists`. The syntax is e.g:

```
ml_tracks [field=]text [command] [number]
```

where text is the search word to look for (currently only a single word). Field is the information to search in, so e.g. for tracks you can search in the fields 'title', 'album' and 'artist'. If no field is given then the default 'title' is used. `command` is either 'add' or 'replace' and the number is the number the item you want to play is among the search results. So to play an item will always involve 2 searches, one to figure out what number you want to play and one to actually play it. An example would go like:

``` shell
socos(Kontor|Stopped)> ml_tracks unforgiven
(1) 'The Unforgiven' on 'Black' by 'Metallica'
(2) 'The Unforgiven' on 'Live Shit, Binge And Purge Cd1' by 'Metallica'
(3) 'The Unforgiven Ii' on 'Reload' by 'Metallica'
(4) 'The Unforgiven III' on 'Death Magnetic' by 'Metallica'
socos(Kontor|Stopped)> ml_tracks unforgiven add 1
Added to queue: 'The Unforgiven'
```

A few words (and numbers) on performance. My music lib is ~5387 tracks. On my computer (AMD Phenom(tm) II X4 940 Processor: 3GHz, 4GB Ram) it takes 11 seconds to index them (to make all 4 tables of course), and **less than 10** ms to make a text search in the largest tables (tracks). I must admit that I was a little skeptical about using a file based database, but after seeing this kind of performance I am deeply impressed with Sqlite3.

Since a lot of searches are likely to be repeated, the class also (as a small further optimization of search speed) implement a local cache of the last 10 searches (only local to the soco instance, not saved in file), so repeating a search is a fast as a dictionary lookup (<10^-4s).

In order to support this functionality I also had to make 2 changes to core socos. One is to implement an optional 'command' argument to `help`, which will show you the entire docstring for that command. So you can do e.g. `help ml_tracks` and get multiline help.

I also changed the COMMANDS data structure to be an OrderedDict instead of a normal dict in order to keep the sorting of the commands, so that all 5 ml_\* commands are next to each other. We can always debate the order of the rest later.

I know that it presently can't be merged into master, but I would like some feedback before I rebase.

I also need some input about how to handle the extra dependency Sqlite3. I wasn't sure how to judge if any of the packages in pip that are named something with sqlite 3 are actually what I am looking for (I installed it form the repository), or how to figure that out in general. Should I also also wrap the import statement in try-excepts like some of the other imports.

I hope you find it useful and as always, comments are most welcome.
