### PR TITLE
Changed hasattr __iter__ check to not isinstance(result, str) for Python3 compatibility.

### DIFF
--- a/socos.py
+++ b/socos.py
@@ -81,7 +81,7 @@ def process_cmd(args):
     if result is None:
         pass
 
-    elif hasattr(result, '__iter__'):
+    elif not isinstance(result, str):
         for line in result:
             print(line)
 


### PR DESCRIPTION
Removes iteration of strings in Python3.

Python 2

``` python
hasattr('foo', '__iter__')
False
```

``` python
not isinstance('foo', str)
False
```

Python 3

``` python
hasattr('foo', '__iter__')
True
```

``` python
not isinstance('foo', str)
False
```
