### PR TITLE
Reset bold at end of line in queue, closes #21

### DIFF
--- a/socos/core.py
+++ b/socos/core.py
@@ -221,7 +221,7 @@ def get_queue(sonos):
                 track.creator,
                 track.title,
                 track.album,
-                ANSI_RESET
+                ANSI_RESET,
             )
         )
 


### PR DESCRIPTION
Resets the ansi bold at end of every line, this makes sure that the 'prompt' line `socos(Stue|Playing)>` isn't marked as bold when playing last item in queue.
