### PR TITLE
Change from unnamed conversion specifier to named conversion specifier

### DIFF
--- a/socos/music_lib.py
+++ b/socos/music_lib.py
@@ -58,9 +58,9 @@ class MusicLibrary(object):
         number_of_tables = len(self.cursor.fetchall())
         if number_of_tables == 5:
             yield 'Deleting tables'
-            query = 'DROP TABLE {}'
+            query = 'DROP TABLE {table_name}'
             for table_name in self.data_types:
-                self.cursor.execute(query.format(table_name))
+                self.cursor.execute(query.format(table_name=table_name))
         self.connection.commit()
 
         # Form new tables


### PR DESCRIPTION
Change from unnamed conversion specifier to named conversion specifier for str.format to stop pylint complaint about too many format arguments.

I'm not sure why it complains about that use of str.format, but this seems to fix the issue.
