### PR TITLE
Object orient

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,30 @@
+[MESSAGES CONTROL]
+
+# locally disable too-many-lines is only possible if the disable statement is
+# put into the first line, which is not good practice
+# see https://github.com/SoCo/SoCo/issues/127
+# duplicate code check disabled whilst refactoring of wimp plugin is in
+# progress
+disable=locally-disabled
+
+[REPORTS]
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template={C}: {line:5d},{column:2d}:  {msg} ({symbol})
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=79
+
+[TYPECHECK]
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus extisting member attributes cannot be deduced by static analysis
+ignored-modules=pytest
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 flake8
-pylint
+pylint==1.3.1
+astroid==1.2.1
+logilab-common==0.62.1  # requirement of pylint; pinned as 0.63.0 has problems with Python 3
 rstcheck

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ flake8
 pylint==1.3.1
 astroid==1.2.1
 logilab-common==0.62.1  # requirement of pylint; pinned as 0.63.0 has problems with Python 3
-rstcheck
+rstcheck==0.6

--- a/socos/__init__.py
+++ b/socos/__init__.py
@@ -6,6 +6,6 @@ __version__ = '0.1'
 __website__ = 'https://github.com/SoCo/socos'
 __license__ = 'MIT License'
 
-from .core import process_cmd, shell
+from .core import SoCos
 
-__all__ = ['process_cmd', 'shell']
+__all__ = ['SoCos']

--- a/socos/core.py
+++ b/socos/core.py
@@ -1,4 +1,4 @@
-# pylint: disable=star-args,too-many-arguments,duplicate-code
+# pylint: disable=too-many-arguments,duplicate-code
 
 """The core module exposes the two public functions process_cmd and shell.
 It also contains all private functions used by the two."""
@@ -157,7 +157,8 @@ class SoCos(object):  # pylint: disable=too-many-public-methods
             err(ex)
             return
 
-        # colorama.init() takes over stdout/stderr to give cross-platform colors
+        # colorama.init() takes over stdout/stderr to give cross-platform
+        # colors
         if colorama:
             colorama.init()
 
@@ -200,7 +201,6 @@ class SoCos(object):  # pylint: disable=too-many-public-methods
 
         return func, args
 
-
     def shell(self):
         """Start an interactive shell"""
 
@@ -211,7 +211,8 @@ class SoCos(object):  # pylint: disable=too-many-public-methods
 
         while True:
             try:
-                # Not sure why this is necessary, as there is a player_name attr
+                # Not sure why this is necessary, as there is a player_name
+                # attr
                 if self.current_speaker:
                     # pylint: disable=maybe-no-member
                     speaker = self.current_speaker.player_name
@@ -258,7 +259,7 @@ class SoCos(object):  # pylint: disable=too-many-public-methods
         matches = [cmd for cmd in self.commands.keys() if cmd.startswith(text)]
         return matches[context]
 
-    ##### Helper methods
+    # ### Helper methods
     @staticmethod
     @requires_coordinator
     def get_queue_length(sonos):
@@ -279,8 +280,8 @@ class SoCos(object):  # pylint: disable=too-many-public-methods
             if index != current:
                 return sonos.play_from_queue(index)
         else:
-            error = "Index %d is not within range 1 - %d" %\
-              (index, queue_length)
+            error = "Index %d is not within range 1 - %d" % \
+                    (index, queue_length)
             raise ValueError(error)
 
     def remove_range_from_queue(self, sonos, rem_range):
@@ -298,15 +299,16 @@ class SoCos(object):  # pylint: disable=too-many-public-methods
             index -= 1
             sonos.remove_from_queue(index)
         else:
-            error = "Index %d is not within range 1 - %d" %\
-              (index, queue_length)
+            error = "Index %d is not within range 1 - %d" % \
+                    (index, queue_length)
             raise ValueError(error)
 
-    ##### Here starts the commands
+    # ### Here starts the commands
     @add_command(requires_ip=False, command_name='list')
     def list_ips(self):
         """List available devices"""
-        ip_to_device = {device.ip_address: device for device in soco.discover()}
+        ip_to_device = {device.ip_address: device
+                        for device in soco.discover()}
         ip_addresses = list(ip_to_device.keys())
         ip_addresses.sort()
 
@@ -487,7 +489,7 @@ class SoCos(object):  # pylint: disable=too-many-public-methods
 
     # Add music service commands
     for method_name in ['index', 'tracks', 'albums', 'artists', 'playlists',
-                         'sonos_playlists']:
+                        'sonos_playlists']:
         command_list.append(
             CommandSpec(requires_ip=True, command_name='ml_' + method_name,
                         obj_name='music_lib', method_name=method_name)
@@ -501,7 +503,8 @@ class SoCos(object):  # pylint: disable=too-many-public-methods
 
     @add_command(requires_ip=False, command_name='set')
     def set_speaker(self, arg):
-        """Set the current speaker for the shell session by ip or speaker number
+        """Set the current speaker for the shell session by ip or speaker
+        number
 
         Args:
             arg (str or int): Is either an ip or the number of a speaker as
@@ -530,8 +533,6 @@ class SoCos(object):  # pylint: disable=too-many-public-methods
         def _cmd_summary(item):
             """Format command name and first line of docstring"""
             name, func = item[0], item[1][1]
-            #if isinstance(func, str):
-            #    func = getattr(soco.SoCo, func)
             doc = getattr(func, '__doc__') or ''
             doc = doc.split('\n')[0].lstrip()
             return ' * {cmd:12s} {doc}'.format(cmd=name, doc=doc)

--- a/socos/core.py
+++ b/socos/core.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments,duplicate-code
+# pylint: disable=too-many-arguments,duplicate-code,star-args
 
 """The core module exposes the two public functions process_cmd and shell.
 It also contains all private functions used by the two."""

--- a/socos/music_lib.py
+++ b/socos/music_lib.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# pylint: disable=star-args
 
 """ The music library support for socos """
 

--- a/socos/music_lib.py
+++ b/socos/music_lib.py
@@ -348,5 +348,4 @@ class MusicLibrary(object):
                 if hasattr(value, 'decode'):
                     item_dict[key] = value.encode('utf-8')
             number = '({{: >{}}}) '.format(index_length).format(index + 1)
-            # pylint: disable=star-args
             yield number + print_patterns[data_type].format(**item_dict)

--- a/socos/runner.py
+++ b/socos/runner.py
@@ -7,19 +7,21 @@ import os.path
 BASEDIR = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(BASEDIR, '..'))
 
-from socos import process_cmd, shell
+from socos import SoCos
 
 
 def main():
     """ main switches between (non-)interactive mode """
+    socos = SoCos()
     args = sys.argv[1:]
 
     if args:
         # process command and exit
-        process_cmd(args)
+        socos.process_cmd(args)
     else:
         # start interactive shell
-        shell()
+        #socos.shell()
+        raise NotImplementedError()
 
 if __name__ == '__main__':
     main()

--- a/socos/runner.py
+++ b/socos/runner.py
@@ -20,8 +20,8 @@ def main():
         socos.process_cmd(args)
     else:
         # start interactive shell
-        #socos.shell()
-        raise NotImplementedError()
+        socos.shell()
+
 
 if __name__ == '__main__':
     main()

--- a/socos/utils.py
+++ b/socos/utils.py
@@ -2,6 +2,7 @@
 
 import re
 from functools import wraps
+from soco import SoCo
 
 # matches single numbers ("123") or ranges ("12..34")
 RANGE_PATTERN = re.compile(r'(\d+)(..(\d+))?')
@@ -50,11 +51,10 @@ def requires_coordinator(func):
         into sonos.group.coordinator
         before returning the decorated function.
         """
-
-        sonos = args[0]
-
         args = list(args)
-        args[0] = sonos.group.coordinator
-
+        if isinstance(args[0], SoCo):  # Static method
+            args[0] = args[0].group.coordinator
+        else:  # Ordinary method
+            args[1] = args[1].group.coordinator
         return func(*args, **kwargs)
     return decorated


### PR DESCRIPTION
Hallo socos devs

This is my attempt to object orient socos. Obviously, object oriented is not a goal in itself, but since the usual definition of when to object orient (i.e. you have a bunch of functions that share state) seems to apply here, I thought it was a good idea. It also gets rid of global variables and other such annoying stuff.

A few things to note about the implementation:
 1. There no longer exists such a thing as the dict of commands, it is formed at run-time in two steps. First, when the class is formed, commands specifications are added to a command_list either by decorating methods in the SoCos class e.g:

 ```python
     @add_command(requires_ip=False)
     def partymode(self):
         """Put all the speakers in the same group, a.k.a Party Mode."""
         self.current_speaker.partymode()
 ```

 or by adding command specs to the command_list directly, e.g (line 488):

 ```python
    # Add music service commands
    for method_name in ['index', 'tracks', 'albums', 'artists', 'playlists',
                         'sonos_playlists']:
        command_list.append(
            CommandSpec(requires_ip=True, command_name='ml_' + method_name,
                        obj_name='music_lib', method_name=method_name)
        )
 ```

 Then when the SoCos object is initialised the OrderedDict ``self.commands`` is populated with actual methods. It is not as simple an implementation as keeping a list (with the decorator and all), but it gets rid of the need to manually keep a command list in sync and it is much more flexibly.

 2. In the implementation described in (1), the order in which the commands appear in help (which is maintained), is determined by the order in which methods are defined or command specs added in the class.

 3. I removed the special case where-in you could specify a command by just a string if it was named the same as the corresponding method in soco. It was only every used for one command anyway, so I didn't think it was worth keeping the special case handling. Most of this special case code was in ``_call_func`` which is therefore remove.

 4. I moved the application of the ``requires_coordinator`` decorator into the ``add_command`` decorator. This could be done conveniently by simply passing an extra argument into ``add_command`` and so it fits nicely in there. It also keeps the list of decorators from getting too long.

 5. I also fixed a bug (around 150), wherein, if you called a command that needs an IP without one, you will not only get the custom error message printed out in ``_check_args`` but also an error from an exception when you try to call None with *None. So now, if ``_check_args`` returns None, None, which is the indication of a missing IP, just return immediately.

Please test and let me know what you think.

Regards Kenneth