### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,6 @@ CLASSIFIERS = [
 	'Programming Language :: Python :: 2',
 	'Programming Language :: Python :: 2.7',
 	'Programming Language :: Python :: 3',
-	'Programming Language :: Python :: 3.2',
-	'Programming Language :: Python :: 3.3',
 	'Programming Language :: Python :: 3.4',
 	'Programming Language :: Python :: 3.5',
 	'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
SoCo dropped support for Python 3.3 in SoCo/SoCo#527, so socos cannot (in the long run) continue to support Python 3.3.