### PR TITLE
Auto-deploy tagged versions to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-
+- '2.7'
+- '3.4'
+- '3.5'
+- '3.6'
+- '3.7'
 install:
-  - pip install -r requirements.txt
-  - pip install -r requirements-dev.txt
-  - pip install colorama
-
+- pip install -r requirements.txt
+- pip install -r requirements-dev.txt
+- pip install colorama
 script:
-  - make
+- make
+deploy:
+  provider: pypi
+  user: soco-bot
+  password:
+    secure: EMBPOKJGi8oSppRxbR3smBlI0cSJyEnullnICMONj2nU7lT6IkhvfadRljgbjjZT59Oam6aytDQVrsnkuFlif6omz093uxJcywBmL+NmA9pxuEGX2XhWFfLHkjWPLDm1oSo3L/5IvYESak1qmQAKMgFv3RnAi2mAuoVNO88+/3Q=
+  on:
+    tags: true
+  distributions: sdist bdist_wheel


### PR DESCRIPTION
Auto-deploy a tagged version from Travis-CI to PyPI

Travis-CI docs at https://docs.travis-ci.com/user/deployment/pypi/